### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Add this to your `config/puma.rb`
 # config/puma.rb
 
 # kill off fsevent_watch in development
-plugin :fsevent_cleanup
+if ENV.fetch('RACK_ENV', 'development') == 'development'
+  plugin :fsevent_cleanup
+end
 ```
 
 **Notes**


### PR DESCRIPTION
By default platforms like Heroku run "bundle install" without the development
and test gem groups. Therefore the puma-fsevent_cleanup gem isn't included and
Puma fails to boot because the plugin is missing.